### PR TITLE
优化读磁盘性能

### DIFF
--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/PartitionGroupStoreManager.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/PartitionGroupStoreManager.java
@@ -1550,7 +1550,8 @@ public class PartitionGroupStoreManager implements ReplicableStore, LifeCycle, C
             this(DEFAULT_MAX_MESSAGE_LENGTH, DEFAULT_WRITE_REQUEST_CACHE_SIZE, DEFAULT_FLUSH_INTERVAL_MS,
                     DEFAULT_WRITE_TIMEOUT_MS, DEFAULT_MAX_DIRTY_SIZE, DEFAULT_PRINT_METRIC_INTERVAL_MS,
                     new PositioningStore.Config(PositioningStore.Config.DEFAULT_FILE_DATA_SIZE),
-                    new PositioningStore.Config(PositioningStore.Config.DEFAULT_FILE_DATA_SIZE));
+                    // 索引在读取的时候默认加载到内存中
+                    new PositioningStore.Config(PositioningStore.Config.DEFAULT_FILE_DATA_SIZE, true));
         }
 
         public Config(int maxMessageLength, int writeRequestCacheSize, long flushIntervalMs,

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/PartitionGroupStoreManager.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/PartitionGroupStoreManager.java
@@ -674,7 +674,7 @@ public class PartitionGroupStoreManager implements ReplicableStore, LifeCycle, C
 
             verifyState(true);
 
-            if (waitForFlush()) {
+            if (waitForFlush() && writeCommand.eventListener != null) {
                 writeCommand.eventListener.onEvent(new WriteResult(JoyQueueCode.SE_WRITE_TIMEOUT, null));
             } else {
                 long[] indices = write(writeCommand.messages);

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/Store.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/Store.java
@@ -18,6 +18,7 @@ package org.joyqueue.store;
 import org.joyqueue.domain.QosLevel;
 import org.joyqueue.monitor.BufferPoolMonitorInfo;
 import org.joyqueue.store.file.PositioningStore;
+import org.joyqueue.store.index.IndexItem;
 import org.joyqueue.store.replication.ReplicableStore;
 import org.joyqueue.store.transaction.TransactionStore;
 import org.joyqueue.store.transaction.TransactionStoreManager;
@@ -296,7 +297,7 @@ public class Store extends Service implements StoreService, Closeable, PropertyS
 
     private PositioningStore.Config getIndexStoreConfig(StoreConfig config) {
         return new PositioningStore.Config(config.getIndexFileSize(),
-                config.getFileHeaderSize(), config.getDiskFullRatio());
+                config.getFileHeaderSize(), config.getDiskFullRatio(), IndexItem.STORAGE_SIZE, false);
     }
 
     private PositioningStore.Config getMessageStoreConfig(StoreConfig config) {

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/Store.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/Store.java
@@ -297,7 +297,7 @@ public class Store extends Service implements StoreService, Closeable, PropertyS
 
     private PositioningStore.Config getIndexStoreConfig(StoreConfig config) {
         return new PositioningStore.Config(config.getIndexFileSize(),
-                config.getFileHeaderSize(), config.getDiskFullRatio(), IndexItem.STORAGE_SIZE, false);
+                config.getFileHeaderSize(), config.getDiskFullRatio(), IndexItem.STORAGE_SIZE, true);
     }
 
     private PositioningStore.Config getMessageStoreConfig(StoreConfig config) {

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/file/StoreFile.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/file/StoreFile.java
@@ -112,4 +112,15 @@ public interface StoreFile<T> extends Timed {
      * 文件创建时间
      */
     long timestamp();
+
+    /**
+     * 调用fsync，确保数据写入到磁盘上。
+     * @throws IOException 发生IO异常时抛出
+     */
+    void force() throws IOException;
+
+    /**
+     * 结束写入，文件变为只读。
+     */
+    void closeWrite();
 }

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/file/StoreFileImpl.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/file/StoreFileImpl.java
@@ -17,18 +17,21 @@ package org.joyqueue.store.file;
 
 import org.joyqueue.store.utils.BufferHolder;
 import org.joyqueue.store.utils.PreloadBufferPool;
+import org.joyqueue.toolkit.concurrent.CasLock;
 import org.joyqueue.toolkit.time.SystemClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sun.misc.Cleaner;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.reflect.Method;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.StampedLock;
@@ -48,6 +51,8 @@ public class StoreFileImpl<T> implements StoreFile<T>, BufferHolder {
     private final long filePosition;
     // 文件头长度
     private final int headerSize;
+
+    private final boolean loadOnRead;
     // 对应的File
     private final File file;
     // buffer读写锁：
@@ -55,7 +60,6 @@ public class StoreFileImpl<T> implements StoreFile<T>, BufferHolder {
     // 加载、释放buffer时加写锁；
     private final StampedLock bufferLock = new StampedLock();
     private final LogSerializer<T> serializer;
-    private final long createTimestamp;
     // 缓存页
     private ByteBuffer pageBuffer = null;
     private int bufferType = NO_BUFFER;
@@ -67,21 +71,26 @@ public class StoreFileImpl<T> implements StoreFile<T>, BufferHolder {
     // 当前写入位置
     private int writePosition = 0;
     private long timestamp = -1L;
-    private AtomicBoolean positionLock = new AtomicBoolean(false);
+    // 文件锁，读写文件时加锁
+    private final CasLock fileLock = new CasLock();
+    private AtomicBoolean forced = new AtomicBoolean(false);
 
-    public StoreFileImpl(long filePosition, File base, int headerSize, LogSerializer<T> serializer, PreloadBufferPool bufferPool, int maxFileDataLength) {
+    private FileChannel fileChannel;
+    private RandomAccessFile raf;
+    private volatile boolean writeClosed = true;
+
+    StoreFileImpl(long filePosition, File base, int headerSize, LogSerializer<T> serializer, PreloadBufferPool bufferPool, int maxFileDataLength, boolean loadOnRead) {
         this.filePosition = filePosition;
         this.headerSize = headerSize;
         this.serializer = serializer;
         this.bufferPool = bufferPool;
         this.capacity = maxFileDataLength;
+        this.loadOnRead = loadOnRead;
         this.file = new File(base, String.valueOf(filePosition));
         if (file.exists() && file.length() > headerSize) {
             this.writePosition = (int) (file.length() - headerSize);
             this.flushPosition = writePosition;
         }
-        createTimestamp = SystemClock.now();
-
     }
 
     @Override
@@ -104,12 +113,17 @@ public class StoreFileImpl<T> implements StoreFile<T>, BufferHolder {
                 loadBuffer =
                         fileChannel.map(FileChannel.MapMode.READ_ONLY, headerSize, file.length() - headerSize);
             }
-//            loadBuffer.load();
+            if( loadOnRead ) {
+                loadBuffer.load();
+            }
             pageBuffer = loadBuffer;
             bufferType = MAPPED_BUFFER;
             pageBuffer.clear();
+            forced.set(true);
+        } catch (ClosedByInterruptException cie) {
+            throw cie;
         } catch (Throwable t) {
-//            logger.warn("Exception: ", t);
+            logger.warn("Exception: ", t);
             bufferPool.releaseMMap(this);
             pageBuffer = null;
             throw t;
@@ -124,18 +138,26 @@ public class StoreFileImpl<T> implements StoreFile<T>, BufferHolder {
         }
         ByteBuffer buffer = bufferPool.allocateDirect(this);
         loadDirectBuffer(buffer);
+        writeClosed = false;
     }
 
     private void loadDirectBuffer(ByteBuffer buffer) throws IOException {
-        if (file.exists() && file.length() > headerSize) {
-            try (RandomAccessFile raf = new RandomAccessFile(file, "r");
-                 FileChannel fileChannel = raf.getChannel()) {
-                fileChannel.position(headerSize);
-                int length;
-                do {
-                    length = fileChannel.read(buffer);
-                } while (length > 0);
-            }
+        boolean needLoadFileContent = file.exists() && file.length() > headerSize;
+        boolean writeTimestamp = !file.exists();
+        // 打开文件描述符
+        raf = new RandomAccessFile(file, "rw");
+        fileChannel = raf.getChannel();
+        if (writeTimestamp) {
+            // 第一次创建文件写入头部预留128字节中0位置开始的前8字节长度:文件创建时间戳
+            writeTimestamp();
+        }
+        if (needLoadFileContent) {
+            logger.warn("Reload file for write! size: {}, file: {}.", file.length(), file);
+            fileChannel.position(headerSize);
+            int length;
+            do {
+                length = fileChannel.read(buffer);
+            } while (length > 0);
             buffer.clear();
         }
         this.pageBuffer = buffer;
@@ -143,36 +165,40 @@ public class StoreFileImpl<T> implements StoreFile<T>, BufferHolder {
     }
 
     public long timestamp() {
-
-        if (timestamp <= 0) {
+        if (timestamp == -1L) {
             // 文件存在初始化时间戳
-            timestamp = readTimestamp();
+            readTimestamp();
         }
         return timestamp;
     }
 
-    private long readTimestamp() {
-        if (file.exists() && file.length() > 8) {
-            ByteBuffer timeBuffer = ByteBuffer.allocate(8);
-            try (RandomAccessFile raf = new RandomAccessFile(file, "r");
-                 FileChannel fileChannel = raf.getChannel()) {
-                fileChannel.position(0);
-                fileChannel.read(timeBuffer);
-                timeBuffer.flip();
-                return timeBuffer.getLong();
-            } catch (Exception e) {
-                logger.warn("Error to read timestamp from file: {} header.", file.getAbsolutePath(), e);
-            }
+    private void readTimestamp() {
+        ByteBuffer timeBuffer = ByteBuffer.allocate(8);
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r"); FileChannel fileChannel = raf.getChannel()) {
+            fileChannel.position(0);
+            fileChannel.read(timeBuffer);
+        } catch (FileNotFoundException ignored) {
+            timeBuffer.putLong(0, -1L);
+        } catch (Exception e) {
+            logger.warn("Exception: ", e);
+        } finally {
+            timestamp = timeBuffer.getLong(0);
         }
-        return createTimestamp;
     }
 
-    private void writeTimestamp(FileChannel fileChannel) throws IOException {
-        ByteBuffer timeBuffer = ByteBuffer.allocate(Long.BYTES);
-        timestamp = createTimestamp;
-        timeBuffer.putLong(timestamp);
-        timeBuffer.flip();
-        fileChannel.write(timeBuffer, 0L);
+    private void writeTimestamp() {
+        ByteBuffer timeBuffer = ByteBuffer.allocate(8);
+        long creationTime = SystemClock.now();
+        timeBuffer.putLong(0, creationTime);
+        ensureOpen();
+        try {
+            fileChannel.position(0);
+            fileChannel.write(timeBuffer);
+        } catch (Exception e) {
+            logger.warn("Exception:", e);
+        } finally {
+            timestamp = creationTime;
+        }
     }
 
     @Override
@@ -322,37 +348,29 @@ public class StoreFileImpl<T> implements StoreFile<T>, BufferHolder {
     /**
      * 刷盘
      */
-    // Not thread safe!
     @Override
     public int flush() throws IOException {
         long stamp = bufferLock.readLock();
         try {
-            if (positionLock.compareAndSet(false, true)) {
-                try (RandomAccessFile raf = new RandomAccessFile(file, "rw");
-                     FileChannel fileChannel = raf.getChannel()) {
+            if (writePosition > flushPosition && fileLock.tryLock()) {
 
-                    if (writePosition > flushPosition) {
-                        if (flushPosition == 0) {
-                            writeTimestamp(fileChannel);
-                        }
-                        return flushPageBuffer(fileChannel);
-                    }
-                } catch (Throwable t) {
-                    logger.warn("StoreFileImpl flush exception! file: {}, flushPosition: {}, writePosition: {}.",
-                            file.getAbsolutePath(), flushPosition, writePosition, t);
-                    throw t;
+                try {
+
+                    return flushPageBuffer(fileChannel);
                 } finally {
-                    positionLock.compareAndSet(true, false);
+                    fileLock.unlock();
                 }
+
             }
+            return 0;
         } finally {
             bufferLock.unlockRead(stamp);
         }
-        return 0;
     }
 
 
     private int flushPageBuffer(FileChannel fileChannel) throws IOException {
+        ensureOpen();
         int flushEnd = writePosition;
         ByteBuffer flushBuffer = pageBuffer.asReadOnlyBuffer();
         flushBuffer.position(flushPosition);
@@ -364,28 +382,27 @@ public class StoreFileImpl<T> implements StoreFile<T>, BufferHolder {
             fileChannel.write(flushBuffer);
         }
         flushPosition = flushEnd;
+        if (flushSize > 0) {
+            forced.compareAndSet(true, false);
+        }
         return flushSize;
     }
 
-    // Not thread safe!
     @Override
     public void rollback(int position) throws IOException {
-        while (!positionLock.compareAndSet(false, true)) {
-            Thread.yield();
+        if (position < writePosition) {
+            writePosition = position;
         }
-        try {
-            if (position < writePosition) {
-                writePosition = position;
-            }
-            if (position < flushPosition) {
+        if (position < flushPosition) {
+            fileLock.waitAndLock();
+            try {
                 flushPosition = position;
-                try (RandomAccessFile raf = new RandomAccessFile(file, "rw");
-                     FileChannel fileChannel = raf.getChannel()) {
+                try (RandomAccessFile raf = new RandomAccessFile(file, "rw"); FileChannel fileChannel = raf.getChannel()) {
                     fileChannel.truncate(position + headerSize);
                 }
+            } finally {
+                fileLock.unlock();
             }
-        } finally {
-            positionLock.compareAndSet(true, false);
         }
 
     }
@@ -421,6 +438,23 @@ public class StoreFileImpl<T> implements StoreFile<T>, BufferHolder {
             unloadMappedBuffer();
         } else if (DIRECT_BUFFER == this.bufferType) {
             unloadDirectBuffer();
+
+            try {
+                closeFileChannel();
+            } catch (IOException e) {
+                logger.warn("Close file {} exception: ", file.getAbsolutePath(), e);
+            }
+            writeClosed = true;
+        }
+    }
+
+    private void closeFileChannel() throws IOException {
+        force();
+        if (null != fileChannel) {
+            fileChannel.close();
+        }
+        if (null != raf) {
+            raf.close();
         }
     }
 
@@ -463,5 +497,40 @@ public class StoreFileImpl<T> implements StoreFile<T>, BufferHolder {
     @Override
     public boolean evict() {
         return unload();
+    }
+
+    @Override
+    public void force() throws IOException {
+        if(forced.compareAndSet(false, true)) {
+            fileLock.waitAndLock();
+            ensureOpen();
+            try {
+                fileChannel.force(true);
+            } catch (Throwable t) {
+                forced.set(false);
+                throw t;
+            } finally {
+                fileLock.unlock();
+            }
+        }
+    }
+
+    private void ensureOpen() {
+        if (fileChannel == null || !fileChannel.isOpen()) {
+            throw new IllegalStateException(
+                    String.format(
+                            "File %s is not open!", file.getAbsolutePath()
+                    )
+            );
+        }
+    }
+    @Override
+    public void closeWrite() {
+        writeClosed = true;
+    }
+
+    @Override
+    public boolean writable() {
+        return bufferType == DIRECT_BUFFER && !writeClosed;
     }
 }

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/utils/BufferHolder.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/org/joyqueue/store/utils/BufferHolder.java
@@ -38,4 +38,10 @@ public interface BufferHolder extends Timed {
      * @return 释放成功返回true，否则返回false
      */
     boolean evict();
+
+    /**
+     * 是否可写？
+     * @return true：可写，false：只读
+     */
+    boolean writable();
 }

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/test/java/org/joyqueue/store/file/StoreFileTest.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/test/java/org/joyqueue/store/file/StoreFileTest.java
@@ -54,7 +54,9 @@ public class StoreFileTest {
     @Test
     public void timestampTest() throws IOException {
         long start = SystemClock.now();
-        StoreFileImpl<ByteBuffer> storeFile = new StoreFileImpl<>(666L, base, 128, new StoreMessageSerializer(1024), PreloadBufferPool.getInstance(), 1024 * 1024 * 10);
+        StoreFileImpl<ByteBuffer> storeFile = new StoreFileImpl<>(666L, base, 128, new StoreMessageSerializer(1024), PreloadBufferPool.getInstance(), 1024 * 1024 * 10, false);
+        storeFile.append(MessageTestUtils.createMessage(new byte[10]));
+        storeFile.flush();
         long timestamp = storeFile.timestamp();
 //        long timestamp = SystemClock.now();
         long end = SystemClock.now();
@@ -62,11 +64,10 @@ public class StoreFileTest {
         Assert.assertTrue(start <= timestamp);
         Assert.assertTrue(timestamp <= end);
 
-        storeFile.append(MessageTestUtils.createMessage(new byte[10]));
-        storeFile.flush();
+
         storeFile.unload();
 
-        storeFile = new StoreFileImpl<>(666L, base, 128, new StoreMessageSerializer(1024), PreloadBufferPool.getInstance(), 1024 * 1024 * 10);
+        storeFile = new StoreFileImpl<>(666L, base, 128, new StoreMessageSerializer(1024), PreloadBufferPool.getInstance(), 1024 * 1024 * 10, false);
 
         Assert.assertEquals(timestamp, storeFile.timestamp());
 


### PR DESCRIPTION
大量消息积压，消费无法命中缓存时，读消息占用较高的磁盘IO，CPU的负载也很高，考虑能否优化。

存储做了如下优化：

1. 修改了对外内存管理器PreloadBufferPool的换页策略，内存不足的时候，优先换出只读的页避免正在写入的页被频繁的换出换入，大量读磁盘，导致负载升高的问题。
2. 现在写完一个文件之后，在下一个文件第一次刷盘前，会调用fsync强制将上一个文件可能存在与PageCache的数据写入磁盘中。避免由于服务器突然断电导致的末尾连续几个文件坏掉，无法自动恢复的问题。
3. 现在读索引的时候，如果无法命中缓存，会把整个索引文件load到内存中，减少文件随机读。