### PR TITLE
根据物理内存大小自动配置堆外最大内存

### DIFF
--- a/joyqueue-common/joyqueue-toolkit/src/main/java/org/joyqueue/toolkit/format/Format.java
+++ b/joyqueue-common/joyqueue-toolkit/src/main/java/org/joyqueue/toolkit/format/Format.java
@@ -83,4 +83,15 @@ public class Format {
         }
         return size;
     }
+
+    public static int getPercentage(String pctString) {
+        int pct = -1;
+
+        if (pctString != null && pctString.trim().endsWith("%")) {
+            String trimString = pctString.trim();
+            trimString = trimString.substring(0, trimString.length() -1);
+            pct = Integer.parseInt(trimString);
+        }
+        return pct;
+    }
 }


### PR DESCRIPTION
系统参数-DPreloadBufferPool.MaxMemory支持设置为百分比，
比如：-DPreloadBufferPool.MaxMemory=90%。
 
修改后，用于缓存的最大堆外内存取值如下：

1. 如果PreloadBufferPool.MaxMemory设置为整数，直接使用设置值。
2. 如果PreloadBufferPool.MaxMemory设置为百分比，比如：90%，最大堆外内存 = 物理内存 * 90% - 最大堆内存（由JVM参数-Xmx配置）
3. 如果PreloadBufferPool.MaxMemory未设置或者设置了非法值，最大堆外内存 = VM.maxDirectMemory() * 90%。其中VM.maxDirectMemory()取值为JVM参数-XX:MaxDirectMemorySize，如果未设置-XX:MaxDirectMemorySize，取值为JVM参数-Xmx。

验证方法：

系统启动后会打印日志：

[INFO] - org.joyqueue.store.utils.PreloadBufferPool.<init>(PreloadBufferPool.java:103) - Max direct memory: 10.8 GB, core direct memory: 8.7 GB, evict direct memory: 9.8 GB.

其中Max direct memory即为设置的最大堆外内存。