### PR TITLE
解决发消息导致内存直线上升问题处理

### DIFF
--- a/joyqueue-console/joyqueue-data/joyqueue-data-service/src/main/java/org/joyqueue/service/impl/BrokerMessageServiceImpl.java
+++ b/joyqueue-console/joyqueue-data/joyqueue-data-service/src/main/java/org/joyqueue/service/impl/BrokerMessageServiceImpl.java
@@ -22,6 +22,7 @@ import io.openmessaging.KeyValue;
 import io.openmessaging.MessagingAccessPoint;
 import io.openmessaging.OMS;
 import io.openmessaging.OMSBuiltinKeys;
+import io.openmessaging.joyqueue.JoyQueueBuiltinKeys;
 import io.openmessaging.joyqueue.producer.ExtensionProducer;
 import io.openmessaging.message.Message;
 import org.apache.commons.collections.CollectionUtils;
@@ -256,6 +257,7 @@ public class BrokerMessageServiceImpl implements BrokerMessageService {
 
         String[] messages = sendMessage.getMessage().split("\n");
         KeyValue attributes = OMS.newKeyValue();
+        attributes.put(JoyQueueBuiltinKeys.IO_THREADS, 1);
         attributes.put(OMSBuiltinKeys.ACCOUNT_KEY, applicationTokens.get(0).getToken());
         MessagingAccessPoint messagingAccessPoint = OMS.getMessagingAccessPoint(String.format("oms:joyqueue://%s@%s:%s/console", sendMessage.getApp(), broker.getIp(), broker.getPort()), attributes);
         ExtensionProducer producer = (ExtensionProducer) messagingAccessPoint.createProducer();


### PR DESCRIPTION
原因：按照宿主机核数创建IO线程，导致发消息那一刻线程会增加大概300多个，内存增加1.5-2G