### PR TITLE
重试队列拉取比率过低问题

### DIFF
--- a/joyqueue-server/joyqueue-broker-core/src/main/java/org/joyqueue/broker/consumer/CasPartitionManager.java
+++ b/joyqueue-server/joyqueue-broker-core/src/main/java/org/joyqueue/broker/consumer/CasPartitionManager.java
@@ -223,10 +223,20 @@ public class CasPartitionManager implements PartitionManager {
 
         Boolean retry = clusterManager.getConsumerPolicy(TopicName.parse(consumer.getTopic()), consumer.getApp()).getRetry();
         List<Short> masterPartitionList = clusterManager.getLocalPartitions(TopicName.parse(consumer.getTopic()));
-        if (!retry.booleanValue() || !masterPartitionList.contains((short) 0)) {
+
+        if (!retry) {
             logger.debug("retry enable is false.");
             return false;
         }
+        if (randomBound == 1) {
+            return true;
+        } else if (!masterPartitionList.contains((short) 0)) {
+            return false;
+        }
+        /*if (!retry.booleanValue() || !masterPartitionList.contains((short) 0)) {
+            logger.debug("retry enable is false.");
+            return false;
+        }*/
 
         int val = random.nextInt(randomBound);
         // 重试管理中获取从重试分区消费的概率

--- a/joyqueue-server/joyqueue-broker-core/src/main/java/org/joyqueue/broker/consumer/CasPartitionManager.java
+++ b/joyqueue-server/joyqueue-broker-core/src/main/java/org/joyqueue/broker/consumer/CasPartitionManager.java
@@ -233,10 +233,6 @@ public class CasPartitionManager implements PartitionManager {
         } else if (!masterPartitionList.contains((short) 0)) {
             return false;
         }
-        /*if (!retry.booleanValue() || !masterPartitionList.contains((short) 0)) {
-            logger.debug("retry enable is false.");
-            return false;
-        }*/
 
         int val = random.nextInt(randomBound);
         // 重试管理中获取从重试分区消费的概率


### PR DESCRIPTION
通过设置rondom=1来使主题其他broker也可以拉到重试队列消息，其他逻辑保持之前的不变。
rondom设置后大于1的情况 继续保持分区0的broker拉取重试
rondom设置1后 主题所有broker都可以进行重试队列拉取